### PR TITLE
correct number of shares for periodic report

### DIFF
--- a/AVR_Miner.py
+++ b/AVR_Miner.py
@@ -585,6 +585,7 @@ def mine_avr(com, threadid):
 
     start_time = time()
     report_shares = 0
+    last_report_share = 0
     while True:
         try:
             while True:
@@ -1043,7 +1044,7 @@ def mine_avr(com, threadid):
                     elapsed_time = end_time - start_time
                     if (threadid == 0
                             and elapsed_time >= PERIODIC_REPORT_TIME):
-                        report_shares = shares[0] - report_shares
+                        report_shares = shares[0] - last_report_share
                         uptime = calculate_uptime(mining_start_time)
 
                         periodic_report(start_time,
@@ -1052,6 +1053,7 @@ def mine_avr(com, threadid):
                                         hashrate,
                                         uptime)
                         start_time = time()
+                        last_report_share = shares[0]
 
                     sleep(1)
                     break


### PR DESCRIPTION
This is my third PR to correct the periodic report. I am not so sure why @revoxhere always changes it back. The current calculation uses the report_share variable, which may not work correctly if the total accepted shares are less than the previous period. It may cause from taking a too long time to solve the hash or connection issue. The result will be incremental, which is incorrect.

I hope no more fourth time to fix this.