### PR TITLE
Update translations for README files and miners

### DIFF
--- a/Resources/AVR_Miner_langs.json
+++ b/Resources/AVR_Miner_langs.json
@@ -1496,7 +1496,7 @@
         "internal_server_error": " Sisäinen palvelinvirhe.",
         "retrying": " Yritetään uudelleen 10s päästä",
         "mining_user": " Käyttäjä ",
-        "mining_not_exist": " ei ole olemassa.",
+        "mining_not_exist": " ei ole olemassa。",
         "mining_not_exist_warning": " Varmista, että olet syöttänyt käyttäjätunnuksen oikein. Tarkista asetustiedostosi. Yritetään uudelleen 10s päästä",
         "load_config_error": " Virhe ladattaessa asetustiedostoa (",
         "load_config_error_warning": "/Miner_config.cfg). Kokeile poistaa se ja suorittaa konfiguraatio uudelleen. Poistutaan 10s päästä",

--- a/Resources/README_TRANSLATIONS/README_fr_FR.md
+++ b/Resources/README_TRANSLATIONS/README_fr_FR.md
@@ -1,0 +1,264 @@
+<!--
+*** Official Duino Coin README
+*** by revoxhere, 2019-2022
+*** translated by pierrealexaline
+-->
+
+<a href="https://duinocoin.com">
+  <img src="https://github.com/revoxhere/duino-coin/blob/master/Resources/duco.png?raw=true" width="215px" align="right" />
+</a>
+
+<h1>
+  <a href="https://duinocoin.com">
+    <img src="https://github.com/revoxhere/duino-coin/blob/master/Resources/ducobanner.png?raw=true" width="430px" />
+  </a>
+  <br>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/README.md">
+    <img src="https://img.shields.io/badge/English-ff8502.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_es_LATAM.md">
+    <img src="https://img.shields.io/badge/-Espa%C3%B1ol-ff7421?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_zh_CN.md">
+    <img src="https://img.shields.io/badge/简体中文-ff6137.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_pl_PL.md">
+    <img src="https://img.shields.io/badge/Polski-ff4b4c.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_ru_RU.md">
+    <img src="https://img.shields.io/badge/русский-ff3062.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_tr_TR.md">
+    <img src="https://img.shields.io/badge/Türk-ff0079.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_th_TH.md">
+    <img src="https://img.shields.io/badge/-%E0%B9%84%E0%B8%97%E0%B8%A2-ff0092.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_pt_BR.md">
+    <img src="https://img.shields.io/badge/-Portugu%C3%AAs-ff009a.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_de_DE.md">
+    <img src="https://img.shields.io/badge/-Deutsch-ff00b2.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_id_ID.md">
+    <img src="https://img.shields.io/badge/-bahasa Indonesia-ff00ca.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_kr_KR.md">
+    <img src="https://img.shields.io/badge/한국어-ff0ae3.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_sk_SK.md">
+    <img src="https://img.shields.io/badge/slovensky-ff0ae3.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_it_IT.md">
+    <img src="https://img.shields.io/badge/italiano-ff0ae3.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_cz_CZ.md">
+    <img src="https://img.shields.io/badge/%C4%8Desky-ff4b4c.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_in_HI.md">
+    <img src="https://img.shields.io/badge/-Hindi-orange?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_ja_JP.md">
+    <img src="https://img.shields.io/badge/-日本語-orange?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_fi_FI.md">
+    <img src="https://img.shields.io/badge/finnish-121212.svg?style=for-the-badge" /></a>
+</h1>
+<a href="https://wallet.duinocoin.com">
+  <img src="https://img.shields.io/badge/Online Wallet-a202ff.svg?style=for-the-badge&logo=Web" /></a>
+<a href="https://play.google.com/store/apps/details?id=com.pripun.duinocoin">
+  <img src="https://img.shields.io/badge/Android App-eb00cb.svg?style=for-the-badge&logo=Android" /></a>
+<a href="https://github.com/revoxhere/duino-coin/blob/gh-pages/assets/whitepaper.pdf">
+  <img src="https://img.shields.io/badge/whitepaper-ff0095.svg?style=for-the-badge&logo=Academia" /></a>
+<a href="https://youtu.be/im0Tca7EjrA">
+  <img src="https://img.shields.io/badge/Video-Watch-ff0064.svg?style=for-the-badge&logo=Youtube" /></a>
+<a href="https://discord.gg/kvBkccy">
+  <img src="https://img.shields.io/discord/677615191793467402.svg?color=ff283a&label=Discord&logo=Discord&style=for-the-badge" /></a>
+<a href="https://github.com/revoxhere/duino-coin/releases/latest">
+  <img src="https://img.shields.io/badge/release-latest-ff640a.svg?style=for-the-badge" /></a>
+<br>
+
+<h3>
+  Duino-Coin est une monnaie qui peut être minée avec des Arduinos, des cartes ESP8266/32, des Raspberry Pi, des ordinateurs et bien d'autres choses encore
+  (y compris les routeurs Wi-Fi, les téléviseurs intelligents, les smartphones, les montres intelligentes, les SBC, les MCU et même les GPU).
+</h3>
+
+
+| Caractéristiques clés | Spécifications techniques | (Certaines des nombreuses) cartes supportées |
+|-|-|-|
+| 💻 Supporté par un grand nombre de plateformes<br>👥 Une communauté en pleine expansion<br>💱 Facile à utiliser et à échanger<br>(sur DUCO Exchange, Node-S, JustSwap, SushiSwap)<br>🌎 Disponible partout<br>:new: Projet entièrement original et open-source<br>🌳 Convient aux débutants et respectueux de l'environnement<br>💰 Rentable et facile à miner | ⚒️ Algorithme: DUCO-S1<br>♐ Récompenses: supportées par le "système Kolka"<br>aidant à récompenser équitablement les mineurs<br>⚡ Temps de transaction: Instantané<br>🪙 Offre de pièces: Infinie<br>(avec combustion)<br>🔤 Ticker: DUCO (ᕲ)<br>🔢 Décimales: jusqu'à 20 | ♾️ Arduinos<br>(Uno, Nano, Mega, Due, Pro Mini, etc.)<br>📶 ESP8266s<br>(NodeMCU, Wemos, etc.)<br>📶 ESP32s<br>(ESP-WROOM, ESP32-CAM, etc.)<br>🍓 Raspberry Pis<br>(1, 2, Zero (W/WH), 3, 4, Pico, 400)<br>🍊 Orange Pis<br>(Zero, Zero 2, PC, Plus, etc.)<br>⚡ Cartes Teensy 4.1 |
+
+
+## Pour commencer
+
+#### Le moyen le plus simple de commencer avec Duino-Coin est de télécharger [la dernière version](https://github.com/revoxhere/duino-coin/releases/latest) pour votre système d'exploitation.<br>
+Après avoir téléchargé la version, décompressez-la et lancez le programme souhaité.<br>
+Aucune dépendance n'est requise.
+
+Si vous avez besoin d'aide, vous pouvez consulter les guides officiels pour commencer <a href="https://duinocoin.com/getting-started">sur le site officiel</a>.<br>
+Les FAQ et l'aide à la résolution des problèmes se trouvent dans les [Wikis](https://github.com/revoxhere/duino-coin/wiki).<br>
+
+#### Linux (installation manuelle)
+
+```BASH
+sudo apt update
+sudo apt install python3 python3-pip git python3-pil python3-pil.imagetk -y # Installer les dépendances
+git clone https://github.com/revoxhere/duino-coin # Cloner le dépôt Duino-Coin
+cd duino-coin
+python3 -m pip install -r requirements.txt # Installer les dépendances pip
+```
+
+Après avoir fait cela, vous pouvez lancer le logiciel (par exemple `python3 PC_Miner.py`).
+
+#### Windows (installation manuelle)
+
+1. Téléchargez et installez [Python 3](https://www.python.org/downloads/) (assurez-vous d'ajouter Python et Pip à votre PATH)
+2. Téléchargez [le dépôt Duino-Coin](https://github.com/revoxhere/duino-coin/archive/master.zip)
+3. Extrayez l'archive zip que vous avez téléchargée et ouvrez le dossier dans l'invite de commande
+4. Dans l'invite de commande, tapez `py -m pip install -r requirements.txt` pour installer les dépendances pip requises
+
+Après avoir fait cela, vous pouvez lancer le logiciel (double-cliquez simplement sur les fichiers `.py` souhaités ou tapez `py PC_Miner.py` dans l'invite de commande).
+
+#### Raspberry Pi (installation automatique)
+
+```BASH
+wget https://raw.githubusercontent.com/revoxhere/duino-coin/master/Tools/duco-install-rpi.sh
+sudo chmod a+x duco-install-rpi.sh
+./duco-install-rpi.sh
+```
+
+## DUCO, wDUCO, bscDUCO, maticDUCO & celoDUCO
+
+Duino-Coin est une monnaie hybride qui prend en charge à la fois les moyens centralisés et décentralisés de stockage des fonds. Les Duino-Coins peuvent être convertis en wDUCO, bscDUCO ou autres, qui sont les mêmes Duino-Coins mais "enveloppés" (stockés) sur d'autres réseaux en tant que jetons. Un tutoriel d'exemple sur l'utilisation de wDUCO est disponible dans le [wDUCO wiki](https://github.com/revoxhere/duino-coin/wiki/wDUCO-tutorial). Les pièces peuvent être enveloppées directement depuis votre portefeuille Web - cliquez sur le bouton Wrap Coins pour commencer.
+
+## Développement
+
+Les contributions sont ce qui fait de la communauté open source un endroit incroyable pour apprendre, inspirer et créer.<br>
+Toutes les contributions que vous apportez au projet Duino-Coin sont grandement appréciées.
+
+Comment aider?
+
+*   Forker le projet
+*   Créer votre branche de fonctionnalité
+*   Valider vos modifications
+*   Assurez-vous que tout fonctionne comme prévu
+*   Ouvrir une demande de tirage
+
+Le code source du serveur, la documentation pour les appels API et les bibliothèques officielles pour développer vos propres applications pour Duino-Coin sont disponibles dans la branche [useful tools](https://github.com/revoxhere/duino-coin/tree/useful-tools).
+
+
+## Objectifs de récompense de la version 4.0
+
+Capturé avec un multiplicateur normal (pas de boost de week-end)
+| Appareil                | Taux de hachage        | Threads | DUCO/jour | Consommation électrique |
+|-------------------------|------------------------|---------|-----------|-------------------------|
+| Arduino                 | 343 H/s                | 1       | 12        | <0.5 W
+| ESP32                   | 170-180 kH/s           | 2       | 10        | 1.5-2 W
+| ESP32-S2/C3             | 85-96 kH/s             | 1       | 8         | 1-1.5 W
+| ESP8266                 | 66 kH/s                | 1       | 6         | 1-1.5 W
+| Raspberry Pi 4 (LOW)    | 1 MH/s (no fasthash)   | 4       | 6-7       | 6.5 W
+| Raspberry Pi 4 (MED)    | 5.4 MH/s (fasthash)    | 4       | 7-8       | 6.5 W
+| PC basse consommation   |                        | 4       | 4-6       | -
+| Moyenne                 |                        | 4-8     | 6-10      | -
+| Haut de gamme           |                        | 8+      | 10-12     | -
+
+<details>
+  <summary><b>Autres appareils testés et leurs benchmarks</b></summary>
+  
+Veuillez noter que la colonne DUCO/jour a été supprimée depuis que la version 4.0 a modifié le système de récompense.
+| Appareil/CPU/SBC/MCU/puce                                 | Taux de hachage moyen<br>(tous les threads) | Threads de minage | Consommation électrique |
+|-----------------------------------------------------------|--------------------------------------------|-------------------|--------------------------|
+| Raspberry Pi Pico                                         | 18 kH/s                                     | 1                 | 0.3 W                    |
+| Raspberry Pi Zero                                         | 18 kH/s                                     | 1                 | 1.1 W                    |
+| Raspberry Pi 3 **(32bit)**                                | 440 kH/s                                    | 4                 | 5.1 W                    |
+| Raspberry Pi 4 **(32bit)**                                | 740 kH/s                                    | 4                 | 6.4 W                    |
+| Raspberry Pi 4 **(64bit, fasthash)**                      | 6.8 MH/s                                    | 4                 | 6.4 W                    |
+| ODROID XU4                                                | 1.0 MH/s                                    | 8                 | 5 W                      |
+| Atomic Pi                                                 | 690 kH/s                                    | 4                 | 6 W                      |
+| Orange Pi Zero 2                                          | 740 kH/s                                    | 4                 | 2.55 W                   |
+| Khadas Vim 2 Pro                                          | 1.12 MH/s                                   | 8                 | 6.2 W                    |
+| Libre Computers Tritium H5CC                              | 480 kH/s                                    | 4                 | 5 W                      |
+| Libre Computers Le Potato                                 | 410 kH/s                                    | 4                 | 5 W                      |
+| Pine64 ROCK64                                             | 640 kH/s                                    | 4                 | 5 W                      |
+| Intel Celeron G1840                                       | 1.25 MH/s                                   | 2                 | 53 W                     |
+| Intel Core i5-2430M                                       | 1.18 MH/s                                   | 4                 | 35 W                     |
+| Intel Core i5-3230M                                       | 1.52 MH/s                                   | 4                 | 35 W                     |
+| Intel Core i5-5350U                                       | 1.35 MH/s                                   | 4                 | 15 W                     |
+| Intel Core i5-7200U                                       | 1.62 MH/s                                   | 4                 | 15 W                     |
+| Intel Core i5-8300H                                       | 3.67 MH/s                                   | 8                 | 45 W                     |
+| Intel Core i3-4130                                        | 1.45 MH/s                                   | 4                 | 54 W                     |
+| AMD Ryzen 5 2600                                          | 4.9 MH/s                                    | 12                | 65 W                     |
+| AMD Ryzen R1505G **(fasthash)**                           | 8.5 MH/s                                    | 4                 | 35 W                     |
+| Intel Core i7-11370H **(fasthash)**                       | 17.3 MH/s                                   | 8                 | 35 W                     |
+| Realtek RTD1295                                           | 490 kH/s                                    | 4                 | -                        |
+| Realtek RTD1295 **(fasthash)**                            | 3.89 MH/s                                   | 4                 | -                        |
+
+</details>
+
+## Logiciels créés par la communauté
+
+### Veuillez noter que ces logiciels ne sont pas développés par nous et que nous ne garantissons pas que leur utilisation ne se traduira pas par un bannissement de compte. Traitez-les comme une curiosité.
+
+  ### Autres mineurs qui fonctionnent avec Duino-Coin:
+  *   [Dockerized Duino-Coin Miner](https://github.com/simeononsecurity/docker-duino-coin) - Une version Dockerisée du Minero Duino-Coin
+  *   :point_right: [**RP2040-HAT-MINING-C**](https://github.com/Wiznet/RP2040-HAT-MINING-C) - **WIZnet RP2040** stack minero
+  *   [DuinoCoinEthernetMiner](https://github.com/Pumafron/DuinoCoinEthernetMiner) - Minero Arduino Ethernet Shield par Pumafron
+  *   [STM8 DUCO Miner](https://github.com/BBS215/STM8_DUCO_miner) - STM8S firmware pour minar DUCO par BBS215
+  *   [DuinoCoinbyLabVIEW](https://github.com/ericddm/DuinoCoinbyLabVIEW) - minero pour famille LabVIEW par ericddm
+  *   [Duino-JS](https://github.com/Hoiboy19/Duino-JS) - un minero JavaScript que puedes implementar fácilmente en tu sitio web par Hoiboy19
+  *   [Mineuino](https://github.com/VatsaDev/Mineuino) - monetizador de sitios web con Duino par VatsaDev
+  *   [hauchel's duco-related stuff repository](https://github.com/hauchel/duco/) - Collection de varios códigos para minar DUCO en otros microcontroladores
+  *   [duino-coin-php-miner](https://github.com/ricardofiorani/duino-coin-php-miner) - Minero Dockerizado en PHP par ricardofiorani
+  *   [duino-coin-kodi](https://github.com/SandUhrGucker/duino-coin-kodi) - Add-on de minado para Kodi Media Center par SandUhrGucker
+  *   [MineCryptoOnWifiRouter](https://github.com/BastelPichi/MineCryptoOnWifiRouter) - script en Python para minar en routers Wi-Fi par BastelPichi
+  *   [Duino-Coin_Android_Cluster Miner](https://github.com/DoctorEenot/DuinoCoin_android_cluster) - mina con menos conecciones en varios dispositivos par DoctorEenot
+  *   [ESPython DUCO Miner](https://github.com/fabiopolancoe/ESPython-DUCO-Miner) - minero en MicroPython para placas ESP par fabiopolancoe
+  *   [DUCO Miner for Nintendo 3DS](https://github.com/BunkerInnovations/duco-3ds) - minero en Python para Nintendo 3DS par PhereloHD & HGEpro
+  *   [Dockerized DUCO Miner](https://github.com/Alicia426/Dockerized_DUCO_Miner_minimal) - Minero en Docker par Alicia426
+  *   [NodeJS-DuinoCoin-Miner](https://github.com/LDarki/NodeJS-DuinoCoin-Miner/) - minero simple en Node.JS par LDarki
+  *   [d-cpuminer](https://github.com/phantom32-0/d-cpuminer) - minero en C puro par phantom32 & revoxhere
+  *   [Go Miner](https://github.com/yippiez/go-miner) par yippiez
+  *   [ducominer](https://github.com/its5Q/ducominer) par its5Q
+  *   [Directorio de mineros no oficiales](https://github.com/revoxhere/duino-coin/tree/master/Unofficial%20miners)
+      *   [Julia Miner](https://github.com/revoxhere/duino-coin/blob/master/Unofficial%20miners/Julia_Miner.jl) par revoxhere
+      *   [Ruby Miner](https://github.com/revoxhere/duino-coin/blob/master/Unofficial%20miners/Ruby_Miner.rb) par revoxhere
+      *   [Minimal Python Miner (DUCO-S1)](https://github.com/revoxhere/duino-coin/blob/master/Unofficial%20miners/Minimal_PC_Miner.py) par revoxhere
+      *   [Teensy 4.1 code for Arduino IDE](https://github.com/revoxhere/duino-coin/blob/master/Unofficial%20miners/Teensy_code/Teensy_code.ino) par joaquinbvw
+
+  ### Autres outils:
+  *   [Duinogotchi](https://github.com/OSRdesign/duinogotchi) - Projet de Duino-Coin mascotas virtuales par ricaun
+  *   [Duino Miner](https://github.com/g7ltt/Duino-Miner) - Archivos y documentación del minero DUCO basado en Arduino Nano par g7ltt
+  *   [DUINO Mining Rig](https://repalmakershop.com/pages/duino-mining-rig) - Archivos 3D, diseños de PCB e instrucciones para crear tu propio Duino rig par ReP_AL
+  *   [DuinoCoin-balance-Home-Assistant](https://github.com/NL647/DuinoCoin-balance-Home-Assistant) - add-on para Home Assistant mostrando tu saldo par NL647
+  *   [ducopanel](https://github.com/ponsato/ducopanel) - un app GUI para controlar tus mineros Duino-Coin par ponsato
+  *   [Duino AVR Monitor](https://www.microsoft.com/store/apps/9NJ7HPFSR9V5) - app GUI de Windows para monitorear dispositivos AVR minando DUCO par niknak
+  *   [Duino-Coin Arduino library](https://github.com/ricaun/arduino-DuinoCoin) par ricaun
+  *   [DuinoCoinI2C](https://github.com/ricaun/DuinoCoinI2C) - Usa ESP8266/ESP32 como maestros para Arduinos par ricaun
+  *   [Duino-Coin Mining Dashboard](https://lulaschkas.github.io/duco-mining-dashboard/) y ayudante de solución de problemas par Lulaschkas
+  *   [duco-miners](https://github.com/dansinclair25/duco-miners) panel de control de minado CLI hecho par dansinclair25
+  *   [Duco-Coin Symbol Icon ttf](https://github.com/SandUhrGucker/Duco-Coin-Symbol-Icon-ttf-.h) par SandUhrGucker
+  *   [DUCO Monitor](https://siunus.github.io/duco-monitor/) sitio web de estadísticas de cuentas par siunus
+  *   [Duino Stats](https://github.com/Bilaboz/duino-stats) bot oficial de Discord par Bilaboz
+  *   [DuCoWallet](https://github.com/viktor02/DuCoWallet) Wallet GUI par viktor02
+  *   [Duco-widget-ios](https://github.com/naphob/duco-widget-ios) - un widget Duino-Coin para iOS par Naphob
+  *   [Duino Lookup](https://axorax.github.io/duino-lookup/) par axorax
+
+  Tambien puedes ver una lista similar en el [sitio web](https://duinocoin.com/apps).
+
+
+## Licence
+
+Duino-Coin est principalement distribué sous la licence MIT. Consultez le fichier `LICENSE` pour plus d'informations.
+Certains fichiers tiers inclus peuvent avoir des licences différentes - veuillez vérifier leurs déclarations de `LICENSE` (généralement en haut des fichiers source).
+
+## Conditions d'utilisation
+
+Nos conditions d'utilisation sont disponibles ici : <a href="https://duinocoin.com/terms">duinocoin.com/terms</a><br/>
+
+
+## Politique de confidentialité
+
+Notre politique de confidentialité est disponible ici : <a href="https://duinocoin.com/privacy">duinocoin.com/privacy</a><br/>
+
+## Avertissement
+
+Notre avertissement est disponible ici : <a href="https://duinocoin.com/disclaimer">duinocoin.com/disclaimer</a><br/>
+
+
+## Mainteneurs actifs du projet
+
+Créé et maintenu à l'origine par [@revoxhere](https://github.com/revoxhere).<br>
+Un grand merci à tous les [contributeurs](https://github.com/revoxhere/duino-coin/graphs/contributors) qui ont aidé à développer le projet Duino-Coin.<br>
+Visitez [duinocoin.com/team.html](https://duinocoin.com/team.html) pour plus d'informations sur l'équipe Duino-Coin.
+
+<hr>
+
+Lien du projet : [https://github.com/revoxhere/duino-coin/](https://github.com/revoxhere/duino-coin/)
+<br/>
+Lien du site Web : [https://duinocoin.com/](https://duinocoin.com/)
+<br/>
+Page d'état de Duino-Coin : [https://status.duinocoin.com](https://status.duinocoin.com)

--- a/Resources/README_TRANSLATIONS/README_nl_NL.md
+++ b/Resources/README_TRANSLATIONS/README_nl_NL.md
@@ -1,0 +1,265 @@
+<!--
+*** Official Duino Coin README
+*** by revoxhere, 2019-2022
+*** translated by Vulpecula-nl
+-->
+
+<a href="https://duinocoin.com">
+  <img src="https://github.com/revoxhere/duino-coin/blob/master/Resources/duco.png?raw=true" width="215px" align="right" />
+</a>
+
+<h1>
+  <a href="https://duinocoin.com">
+    <img src="https://github.com/revoxhere/duino-coin/blob/master/Resources/ducobanner.png?raw=true" width="430px" />
+  </a>
+  <br>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/README.md">
+    <img src="https://img.shields.io/badge/English-ff8502.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_es_LATAM.md">
+    <img src="https://img.shields.io/badge/-Espa%C3%B1ol-ff7421?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_zh_CN.md">
+    <img src="https://img.shields.io/badge/简体中文-ff6137.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_pl_PL.md">
+    <img src="https://img.shields.io/badge/Polski-ff4b4c.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_ru_RU.md">
+    <img src="https://img.shields.io/badge/русский-ff3062.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_tr_TR.md">
+    <img src="https://img.shields.io/badge/Türk-ff0079.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_th_TH.md">
+    <img src="https://img.shields.io/badge/-%E0%B9%84%E0%B8%97%E0%B8%A2-ff0092.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_pt_BR.md">
+    <img src="https://img.shields.io/badge/-Portugu%C3%AAs-ff009a.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_de_DE.md">
+    <img src="https://img.shields.io/badge/-Deutsch-ff00b2.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_id_ID.md">
+    <img src="https://img.shields.io/badge/-bahasa Indonesia-ff00ca.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_kr_KR.md">
+    <img src="https://img.shields.io/badge/한국어-ff0ae3.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_sk_SK.md">
+    <img src="https://img.shields.io/badge/slovensky-ff0ae3.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_it_IT.md">
+    <img src="https://img.shields.io/badge/italiano-ff0ae3.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_cz_CZ.md">
+    <img src="https://img.shields.io/badge/%C4%8Desky-ff4b4c.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_in_HI.md">
+    <img src="https://img.shields.io/badge/-Hindi-orange?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_ja_JP.md">
+    <img src="https://img.shields.io/badge/-日本語-orange?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_fi_FI.md">
+    <img src="https://img.shields.io/badge/finnish-121212.svg?style=for-the-badge" /></a>
+</h1>
+<a href="https://wallet.duinocoin.com">
+  <img src="https://img.shields.io/badge/Online Wallet-a202ff.svg?style=for-the-badge&logo=Web" /></a>
+<a href="https://play.google.com/store/apps/details?id=com.pripun.duinocoin">
+  <img src="https://img.shields.io/badge/Android App-eb00cb.svg?style=for-the-badge&logo=Android" /></a>
+<a href="https://github.com/revoxhere/duino-coin/blob/gh-pages/assets/whitepaper.pdf">
+  <img src="https://img.shields.io/badge/whitepaper-ff0095.svg?style=for-the-badge&logo=Academia" /></a>
+<a href="https://youtu.be/im0Tca7EjrA">
+  <img src="https://img.shields.io/badge/Video-Watch-ff0064.svg?style=for-the-badge&logo=Youtube" /></a>
+<a href="https://discord.gg/kvBkccy">
+  <img src="https://img.shields.io/discord/677615191793467402.svg?color=ff283a&label=Discord&logo=Discord&style=for-the-badge" /></a>
+<a href="https://github.com/revoxhere/duino-coin/releases/latest">
+  <img src="https://img.shields.io/badge/release-latest-ff640a.svg?style=for-the-badge" /></a>
+<br>
+
+<h3>
+  Duino-Coin is een munt die kan worden gemijnd met Arduinos, ESP8266/32-boards, Raspberry Pi's, computers en nog veel meer
+  (inclusief Wi-Fi-routers, smart-tv's, smartphones, smartwatches, SBC's, MCU's en zelfs GPU's)
+</h3>
+
+
+| Belangrijkste kenmerken | Technische specificaties | (Enkele van de vele) ondersteunde borden |
+|-|-|-|
+| 💻 Ondersteund door een groot aantal platforms<br>👥 Een snelgroeiende gemeenschap<br>💱 Gemakkelijk te gebruiken en te ruilen<br>(op DUCO Exchange, Node-S, JustSwap, SushiSwap)<br>🌎 Overal beschikbaar<br>:new: Volledig origineel en open-source project<br>🌳 Beginners- en milieuvriendelijk<br>💰 Kosteneffectief en gemakkelijk te minen | ⚒️ Algoritme: DUCO-S1<br>♐ Beloningen: ondersteund door het "Kolka-systeem"<br>helpen om mijnwerkers eerlijk te belonen<br>⚡ Transactietijd: Onmiddellijk<br>🪙 Muntvoorraad: Oneindig<br>(met verbranding)<br>🔤 Ticker: DUCO (ᕲ)<br>🔢 Decimalen: tot 20 | ♾️ Arduinos<br>(Uno, Nano, Mega, Due, Pro Mini, enz.)<br>📶 ESP8266s<br>(NodeMCU, Wemos, enz.)<br>📶 ESP32s<br>(ESP-WROOM, ESP32-CAM, enz.)<br>🍓 Raspberry Pi's<br>(1, 2, Zero (W/WH), 3, 4, Pico, 400)<br>🍊 Orange Pi's<br>(Zero, Zero 2, PC, Plus, enz.)<br>⚡ Teensy 4.1 borden |
+
+
+## Beginnen
+
+#### De gemakkelijkste manier om aan de slag te gaan met Duino-Coin is door [de nieuwste release](https://github.com/revoxhere/duino-coin/releases/latest) voor uw besturingssysteem te downloaden.<br>
+Pak na het downloaden van de release het bestand uit en start het gewenste programma.<br>
+Er zijn geen afhankelijkheden vereist.
+
+Als je hulp nodig hebt, kun je de officiële handleidingen bekijken <a href="https://duinocoin.com/getting-started">op de officiële website</a>.<br>
+Veelgestelde vragen en probleemoplossing zijn te vinden in de [Wiki's](https://github.com/revoxhere/duino-coin/wiki).<br>
+
+#### Linux (handmatige installatie)
+
+```BASH
+sudo apt update
+sudo apt install python3 python3-pip git python3-pil python3-pil.imagetk -y # Installeer afhankelijkheden
+git clone https://github.com/revoxhere/duino-coin # Clone Duino-Coin repository
+cd duino-coin
+python3 -m pip install -r requirements.txt # Installeer pip-afhankelijkheden
+```
+
+Nadat u dit heeft gedaan, kunt u de software starten (bijv. `python3 PC_Miner.py`).
+
+#### Windows (handmatige installatie)
+
+1. Download en installeer [Python 3](https://www.python.org/downloads/) (zorg ervoor dat je Python en Pip toevoegt aan je PATH)
+2. Download [de Duino-Coin repository](https://github.com/revoxhere/duino-coin/archive/master.zip)
+3. Pak het zip-archief uit dat je hebt gedownload en open de map in de opdrachtprompt
+4. Typ in de opdrachtprompt `py -m pip install -r requirements.txt` om de vereiste pip-afhankelijkheden te installeren
+
+Nadat u dit heeft gedaan, kunt u de software starten (dubbelklik gewoon op de gewenste `.py`-bestanden of typ `py PC_Miner.py` in de opdrachtprompt).
+
+#### Raspberry Pi (automatische installatie)
+
+```BASH
+wget https://raw.githubusercontent.com/revoxhere/duino-coin/master/Tools/duco-install-rpi.sh
+sudo chmod a+x duco-install-rpi.sh
+./duco-install-rpi.sh
+```
+
+## DUCO, wDUCO, bscDUCO, maticDUCO & celoDUCO
+
+Duino-Coin is een hybride valuta die ondersteuning biedt voor zowel gecentraliseerde als gedecentraliseerde manieren om geld op te slaan. Duino-Coins kunnen worden omgezet in wDUCO, bscDUCO of andere die dezelfde Duino-Coins zijn, maar "gewikkeld" (opgeslagen) op andere netwerken als tokens. Een voorbeeldtutorial over het gebruik van wDUCO is beschikbaar in de [wDUCO wiki](https://github.com/revoxhere/duino-coin/wiki/wDUCO-tutorial). Munten kunnen rechtstreeks vanuit uw webportemonnee worden verpakt - klik op de knop Wrap Coins om te beginnen.
+
+## Ontwikkeling
+
+Bijdragen zijn wat de open source-gemeenschap zo'n geweldige plek maakt om te leren, te inspireren en te creëren.<br>
+Alle bijdragen die u levert aan het Duino-Coin-project worden zeer op prijs gesteld.
+
+Hoe te helpen?
+
+*   Fork het project
+*   Maak je functietak
+*   Dien uw wijzigingen in
+*   Zorg ervoor dat alles werkt zoals bedoeld
+*   Open een pull-verzoek
+
+Serverbroncode, documentatie voor API-aanroepen en officiële bibliotheken voor het ontwikkelen van uw eigen apps voor Duino-Coin zijn beschikbaar in de [nuttige tools](https://github.com/revoxhere/duino-coin/tree/useful-tools) tak.
+
+
+## Versie 4.0 beloningsdoelen
+
+Vastgelegd met normale vermenigvuldiger (geen weekendboost)
+| Apparaat                | Hashrate            | Threads | DUCO/dag | Energieverbruik |
+|-------------------------|---------------------|---------|----------|-----------------|
+| Arduino                 | 343 H/s             | 1       | 12       | <0.5 W
+| ESP32                   | 170-180 kH/s        | 2       | 10       | 1.5-2 W
+| ESP32-S2/C3             | 85-96 kH/s          | 1       | 8        | 1-1.5 W
+| ESP8266                 | 66 kH/s             | 1       | 6        | 1-1.5 W
+| Raspberry Pi 4 (LOW)    | 1 MH/s (no fasthash)| 4       | 6-7      | 6.5 W
+| Raspberry Pi 4 (MED)    | 5.4 MH/s (fasthash) | 4       | 7-8      | 6.5 W
+| Laag vermogen pc's      |                     | 4       | 4-6      | -
+| Medium                  |                     | 4-8     | 6-10     | -
+| High end                |                     | 8+      | 10-12    | -
+
+<details>
+  <summary><b>Andere geteste apparaten en hun benchmarks</b></summary>
+  
+Houd er rekening mee dat de kolom DUCO/dag is verwijderd sinds versie 4.0 het beloningssysteem heeft gewijzigd.
+| Apparaat/CPU/SBC/MCU/chip                                   | Gemiddelde hashrate<br>(alle threads) | Mijnbouw<br>threads | Energieverbruik |
+|-------------------------------------------------------------|---------------------------------------|---------------------|-----------------|
+| Raspberry Pi Pico                                           | 18 kH/s                               | 1                   | 0.3 W           |
+| Raspberry Pi Zero                                           | 18 kH/s                               | 1                   | 1.1 W           |
+| Raspberry Pi 3 **(32bit)**                                  | 440 kH/s                              | 4                   | 5.1 W           |
+| Raspberry Pi 4 **(32bit)**                                  | 740 kH/s                              | 4                   | 6.4 W           |
+| Raspberry Pi 4 **(64bit, fasthash)**                        | 6.8 MH/s                              | 4                   | 6.4 W           |
+| ODROID XU4                                                  | 1.0 MH/s                              | 8                   | 5 W             |
+| Atomic Pi                                                   | 690 kH/s                              | 4                   | 6 W             |
+| Orange Pi Zero 2                                            | 740 kH/s                              | 4                   | 2.55 W          |
+| Khadas Vim 2 Pro                                            | 1.12 MH/s                             | 8                   | 6.2 W           |
+| Libre Computers Tritium H5CC                                | 480 kH/s                              | 4                   | 5 W             |
+| Libre Computers Le Potato                                   | 410 kH/s                              | 4                   | 5 W             |
+| Pine64 ROCK64                                               | 640 kH/s                              | 4                   | 5 W             |
+| Intel Celeron G1840                                         | 1.25 MH/s                             | 2                   | 53 W            |
+| Intel Core i5-2430M                                         | 1.18 MH/s                             | 4                   | 35 W            |
+| Intel Core i5-3230M                                         | 1.52 MH/s                             | 4                   | 35 W            |
+| Intel Core i5-5350U                                         | 1.35 MH/s                             | 4                   | 15 W            |
+| Intel Core i5-7200U                                         | 1.62 MH/s                             | 4                   | 15 W            |
+| Intel Core i5-8300H                                         | 3.67 MH/s                             | 8                   | 45 W            |
+| Intel Core i3-4130                                          | 1.45 MH/s                             | 4                   | 54 W            |
+| AMD Ryzen 5 2600                                            | 4.9 MH/s                              | 12                  | 65 W            |
+| AMD Ryzen R1505G **(fasthash)**                             | 8.5 MH/s                              | 4                   | 35 W            |
+| Intel Core i7-11370H **(fasthash)**                         | 17.3 MH/s                             | 8                   | 35 W            |
+| Realtek RTD1295                                             | 490 kH/s                              | 4                   | -               |
+| Realtek RTD1295 **(fasthash)**                              | 3.89 MH/s                             | 4                   | -               |
+
+</details>
+
+## Door de gemeenschap gemaakte software
+
+### Houd er rekening mee dat deze software niet door ons is ontwikkeld en dat we niet garanderen dat het gebruik ervan niet zal resulteren in een verbod op een account. Behandel ze als een nieuwsgierigheid.
+
+  ### Andere mijnwerkers die werken met Duino-Coin:
+  *   [Dockerized Duino-Coin Miner](https://github.com/simeononsecurity/docker-duino-coin) - Een Dockerized versie van de Duino-Coin Miner
+  *   :point_right: [**RP2040-HAT-MINING-C**](https://github.com/Wiznet/RP2040-HAT-MINING-C) - **WIZnet RP2040** mijnbouwstapel
+  *   [DuinoCoinEthernetMiner](https://github.com/Pumafron/DuinoCoinEthernetMiner) - Arduino Ethernet Shield Miner van Pumafron
+  *   [STM8 DUCO Miner](https://github.com/BBS215/STM8_DUCO_miner) - STM8S firmware voor het minen van DUCO door BBS215
+  *   [DuinoCoinbyLabVIEW](https://github.com/ericddm/DuinoCoinbyLabVIEW) - mijnwerker voor LabVIEW-familie door ericddm
+  *   [Duino-JS](https://github.com/Hoiboy19/Duino-JS) - een JavaScript-mijnwerker die je gemakkelijk op je site kunt implementeren door Hoiboy19
+  *   [Duinotize](https://github.com/mobilegmYT/Duinotize) - Duino-website-monetizer door mobilegmYT
+  *   [hauchel's duco-related stuff repository](https://github.com/hauchel/duco/) - Verzameling van verschillende codes voor het minen van DUCO op andere microcontrollers
+  *   [duino-coin-php-miner](https://github.com/ricardofiorani/duino-coin-php-miner) Dockerized Miner in PHP door ricardofiorani
+  *   [duino-coin-kodi](https://github.com/SandUhrGucker/duino-coin-kodi) - Mijnbouw-add-on voor Kodi Media Center door SandUhrGucker
+  *   [MineCryptoOnWifiRouter](https://github.com/BastelPichi/MineCryptoOnWifiRouter) - Python-script om Duino-Coin te minen op routers door BastelPichi
+  *   [Duino-Coin_Android_Cluster Miner](https://github.com/DoctorEenot/DuinoCoin_android_cluster) - mijn met minder verbindingen op meerdere apparaten door DoctorEenot
+  *   [ESPython DUCO Miner](https://github.com/fabiopolancoe/ESPython-DUCO-Miner) - MicroPython-mijnwerker voor ESP-boards door fabiopolancoe
+  *   [DUCO Miner for Nintendo 3DS](https://github.com/BunkerInnovations/duco-3ds) - Python-mijnwerker voor Nintendo 3DS door PhereloHD & HGEpro
+  *   [Dockerized DUCO Miner](https://github.com/Alicia426/Dockerized_DUCO_Miner_minimal) - Miner in Docker door Alicia426
+  *   [NodeJS-DuinoCoin-Miner](https://github.com/LDarki/NodeJS-DuinoCoin-Miner/) - eenvoudige NodeJS-mijnwerker door LDarki
+  *   [d-cpuminer](https://github.com/phantom32-0/d-cpuminer) - pure C-mijnwerker door phantom32 & revoxhere
+  *   [Go Miner](https://github.com/yippiez/go-miner) door yippiez
+  *   [ducominer](https://github.com/its5Q/ducominer) door its5Q
+  *   [Onofficiële mijnwerkersdirectory](https://github.com/revoxhere/duino-coin/tree/master/Unofficial%20miners)
+      *   [Julia Miner](https://github.com/revoxhere/duino-coin/blob/master/Unofficial%20miners/Julia_Miner.jl) door revoxhere
+      *   [Ruby Miner](https://github.com/revoxhere/duino-coin/blob/master/Unofficial%20miners/Ruby_Miner.rb) door revoxhere
+      *   [Minimal Python Miner (DUCO-S1)](https://github.com/revoxhere/duino-coin/blob/master/Unofficial%20miners/Minimal_PC_Miner.py) door revoxhere
+      *   [Teensy 4.1 code for Arduino IDE](https://github.com/revoxhere/duino-coin/blob/master/Unofficial%20miners/Teensy_code/Teensy_code.ino) door joaquinbvw
+
+  ### Andere hulpmiddelen:
+  *   [Duinogotchi](https://github.com/OSRdesign/duinogotchi) - Duino-Coin virtueel huisdierproject door OSRdesign
+  *   [Duino Miner](https://github.com/g7ltt/Duino-Miner) - Arduino Nano-gebaseerde DUCO-mijnwerkersbestanden en documentatie door g7ltt
+  *   [DUINO Mining Rig](https://repalmakershop.com/pages/duino-mining-rig) - 3D-bestanden, PCB-ontwerpen en instructies voor het maken van je eigen Duino-rig door ReP_AL
+  *   [DuinoCoin-balance-Home-Assistant](https://github.com/NL647/DuinoCoin-balance-Home-Assistant) - add-on voor home assistant die je saldo weergeeft door NL647
+  *   [ducopanel](https://github.com/ponsato/ducopanel) - een GUI-app voor het bedienen van je Duino-Coin-mijnwerkers door ponsato
+  *   [Duino AVR Monitor](https://www.microsoft.com/store/apps/9NJ7HPFSR9V5) - GUI Windows-app voor het bewaken van AVR-apparaten die DUCO minen door niknak
+  *   [Duino-Coin Arduino library](https://github.com/ricaun/arduino-DuinoCoin) door ricaun
+  *   [DuinoCoinI2C](https://github.com/ricaun/DuinoCoinI2C) - Gebruik ESP8266/ESP32 als master voor Arduinos door ricaun
+  *   [Duino-Coin Mining Dashboard](https://lulaschkas.github.io/duco-mining-dashboard/) en probleemoplosser door Lulaschkas
+  *   [duco-miners](https://github.com/dansinclair25/duco-miners) CLI-mijnbouwdashboard gemaakt door dansinclair25
+  *   [Duco-Coin Symbol Icon ttf](https://github.com/SandUhrGucker/Duco-Coin-Symbol-Icon-ttf-.h) door SandUhrGucker
+  *   [DUCO Monitor](https://siunus.github.io/duco-monitor/) accountstatistiekenwebsite door siunus
+  *   [Duino Stats](https://github.com/Bilaboz/duino-stats) officiële Discord-bot door Bilaboz
+  *   [DuCoWallet](https://github.com/viktor02/DuCoWallet) GUI Wallet door viktor02
+  *   [Duco-widget-ios](https://github.com/naphob/duco-widget-ios) - een Duino-Coin iOS-widget door Naphob
+  *   [Duino Lookup](https://axorax.github.io/duino-lookup/) door axorax
+
+ U kunt ook een vergelijkbare lijst bekijken op de [website](https://duinocoin.com/apps).
+
+
+## Licentie
+
+Duino-Coin wordt voornamelijk gedistribueerd onder de MIT-licentie. Zie het bestand `LICENSE` voor meer informatie.
+Sommige meegeleverde bestanden van derden kunnen verschillende licenties hebben - controleer hun `LICENSE`-verklaringen (meestal bovenaan de broncodebestanden).
+
+
+## Servicevoorwaarden
+
+Onze servicevoorwaarden zijn hier beschikbaar: <a href="https://duinocoin.com/terms">duinocoin.com/terms</a><br/>
+
+
+## Privacybeleid
+
+Ons privacybeleid is hier beschikbaar: <a href="https://duinocoin.com/privacy">duinocoin.com/privacy</a><br/>
+
+## Disclaimer
+
+Onze disclaimer is hier beschikbaar: <a href="https://duinocoin.com/disclaimer">duinocoin.com/disclaimer</a><br/>
+
+
+## Actieve projectonderhouders
+
+Oorspronkelijk gemaakt en onderhouden door [@revoxhere](https://github.com/revoxhere).<br>
+Heel erg bedankt aan alle [bijdragers](https://github.com/revoxhere/duino-coin/graphs/contributors) die hebben geholpen bij de ontwikkeling van het Duino-Coin-project.<br>
+Bezoek [duinocoin.com/team.html](https://duinocoin.com/team.html) voor meer informatie over het Duino-Coin-team.
+
+<hr>
+
+Projectlink: [https://github.com/revoxhere/duino-coin/](https://github.com/revoxhere/duino-coin/)
+<br/>
+Website link: [https://duinocoin.com/](https://duinocoin.com/)
+<br/>
+Duino-Coin statuspagina: [https://status.duinocoin.com](https://status.duinocoin.com)

--- a/Resources/README_TRANSLATIONS/README_vi_VN.md
+++ b/Resources/README_TRANSLATIONS/README_vi_VN.md
@@ -1,0 +1,265 @@
+<!--
+*** Official Duino Coin README
+*** by revoxhere, 2019-2022
+*** translated by MinatoIsuki
+-->
+
+<a href="https://duinocoin.com">
+  <img src="https://github.com/revoxhere/duino-coin/blob/master/Resources/duco.png?raw=true" width="215px" align="right" />
+</a>
+
+<h1>
+  <a href="https://duinocoin.com">
+    <img src="https://github.com/revoxhere/duino-coin/blob/master/Resources/ducobanner.png?raw=true" width="430px" />
+  </a>
+  <br>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/README.md">
+    <img src="https://img.shields.io/badge/English-ff8502.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_es_LATAM.md">
+    <img src="https://img.shields.io/badge/-Espa%C3%B1ol-ff7421?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_zh_CN.md">
+    <img src="https://img.shields.io/badge/简体中文-ff6137.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_pl_PL.md">
+    <img src="https://img.shields.io/badge/Polski-ff4b4c.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_ru_RU.md">
+    <img src="https://img.shields.io/badge/русский-ff3062.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_tr_TR.md">
+    <img src="https://img.shields.io/badge/Türk-ff0079.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_th_TH.md">
+    <img src="https://img.shields.io/badge/-%E0%B9%84%E0%B8%97%E0%B8%A2-ff0092.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_pt_BR.md">
+    <img src="https://img.shields.io/badge/-Portugu%C3%AAs-ff009a.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_de_DE.md">
+    <img src="https://img.shields.io/badge/-Deutsch-ff00b2.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_id_ID.md">
+    <img src="https://img.shields.io/badge/-bahasa Indonesia-ff00ca.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_kr_KR.md">
+    <img src="https://img.shields.io/badge/한국어-ff0ae3.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_sk_SK.md">
+    <img src="https://img.shields.io/badge/slovensky-ff0ae3.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_it_IT.md">
+    <img src="https://img.shields.io/badge/italiano-ff0ae3.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_cz_CZ.md">
+    <img src="https://img.shields.io/badge/%C4%8Desky-ff4b4c.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_in_HI.md">
+    <img src="https://img.shields.io/badge/-Hindi-orange?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_ja_JP.md">
+    <img src="https://img.shields.io/badge/-日本語-orange?style=for-the-badge" /></a>
+  <a href="https://github.com/revoxhere/duino-coin/blob/master/Resources/README_TRANSLATIONS/README_fi_FI.md">
+    <img src="https://img.shields.io/badge/finnish-121212.svg?style=for-the-badge" /></a>
+</h1>
+<a href="https://wallet.duinocoin.com">
+  <img src="https://img.shields.io/badge/Online Wallet-a202ff.svg?style=for-the-badge&logo=Web" /></a>
+<a href="https://play.google.com/store/apps/details?id=com.pripun.duinocoin">
+  <img src="https://img.shields.io/badge/Android App-eb00cb.svg?style=for-the-badge&logo=Android" /></a>
+<a href="https://github.com/revoxhere/duino-coin/blob/gh-pages/assets/whitepaper.pdf">
+  <img src="https://img.shields.io/badge/whitepaper-ff0095.svg?style=for-the-badge&logo=Academia" /></a>
+<a href="https://youtu.be/im0Tca7EjrA">
+  <img src="https://img.shields.io/badge/Video-Watch-ff0064.svg?style=for-the-badge&logo=Youtube" /></a>
+<a href="https://discord.gg/kvBkccy">
+  <img src="https://img.shields.io/discord/677615191793467402.svg?color=ff283a&label=Discord&logo=Discord&style=for-the-badge" /></a>
+<a href="https://github.com/revoxhere/duino-coin/releases/latest">
+  <img src="https://img.shields.io/badge/release-latest-ff640a.svg?style=for-the-badge" /></a>
+<br>
+
+<h3>
+  Duino-Coin là một đồng tiền có thể được khai thác bằng Arduinos, bảng ESP8266/32, Raspberry Pis, máy tính và nhiều thứ khác
+  (bao gồm cả bộ định tuyến Wi-Fi, TV thông minh, điện thoại thông minh, đồng hồ thông minh, SBC, MCU và thậm chí cả GPU)
+</h3>
+
+
+| Các tính năng chính | Thông số kỹ thuật | (Một số trong nhiều) bảng được hỗ trợ |
+|-|-|-|
+| 💻 Được hỗ trợ bởi nhiều nền tảng<br>👥 Một cộng đồng đang phát triển nhanh chóng<br>💱 Dễ sử dụng và trao đổi<br>(trên DUCO Exchange, Node-S, JustSwap, SushiSwap)<br>🌎 Có sẵn ở mọi nơi<br>:new: Dự án hoàn toàn độc đáo và mã nguồn mở<br>🌳 Thân thiện với người mới bắt đầu và thân thiện với môi trường<br>💰 Hiệu quả về chi phí và dễ khai thác | ⚒️ Thuật toán: DUCO-S1<br>♐ Phần thưởng: được hỗ trợ bởi "hệ thống Kolka"<br>giúp thưởng cho các thợ mỏ một cách công bằng<br>⚡ Thời gian giao dịch: Ngay lập tức<br>🪙 Nguồn cung tiền xu: Vô hạn<br>(với đốt)<br>🔤 Ticker: DUCO (ᕲ)<br>🔢 Số thập phân: lên đến 20 | ♾️ Arduinos<br>(Uno, Nano, Mega, Due, Pro Mini, v.v.)<br>📶 ESP8266s<br>(NodeMCU, Wemos, v.v.)<br>📶 ESP32s<br>(ESP-WROOM, ESP32-CAM, v.v.)<br>🍓 Raspberry Pis<br>(1, 2, Zero (W/WH), 3, 4, Pico, 400)<br>🍊 Orange Pis<br>(Zero, Zero 2, PC, Plus, v.v.)<br>⚡ Bảng Teensy 4.1 |
+
+
+## Bắt đầu
+
+#### Cách dễ nhất để bắt đầu với Duino-Coin là tải xuống [bản phát hành mới nhất](https://github.com/revoxhere/duino-coin/releases/latest) cho hệ điều hành của bạn.<br>
+Sau khi tải xuống bản phát hành, hãy giải nén và khởi chạy chương trình mong muốn.<br>
+Không có sự phụ thuộc nào được yêu cầu.
+
+Nếu bạn cần trợ giúp, bạn có thể xem các hướng dẫn bắt đầu chính thức <a href="https://duinocoin.com/getting-started">trên trang web chính thức</a>.<br>
+Câu hỏi thường gặp và trợ giúp khắc phục sự cố có thể được tìm thấy trong [Wiki](https://github.com/revoxhere/duino-coin/wiki).<br>
+
+#### Linux (cài đặt thủ công)
+
+```BASH
+sudo apt update
+sudo apt install python3 python3-pip git python3-pil python3-pil.imagetk -y # Cài đặt các phụ thuộc
+git clone https://github.com/revoxhere/duino-coin # Nhân bản kho lưu trữ Duino-Coin
+cd duino-coin
+python3 -m pip install -r requirements.txt # Cài đặt các phụ thuộc pip
+```
+
+Sau khi làm điều này, bạn có thể khởi chạy phần mềm (ví dụ: `python3 PC_Miner.py`).
+
+#### Windows (cài đặt thủ công)
+
+1. Tải xuống và cài đặt [Python 3](https://www.python.org/downloads/) (đảm bảo thêm Python và Pip vào PATH của bạn)
+2. Tải xuống [kho lưu trữ Duino-Coin](https://github.com/revoxhere/duino-coin/archive/master.zip)
+3. Giải nén tệp zip bạn đã tải xuống và mở thư mục trong dấu nhắc lệnh
+4. Trong dấu nhắc lệnh, hãy nhập `py -m pip install -r requirements.txt` để cài đặt các phụ thuộc pip cần thiết
+
+Sau khi làm điều này, bạn có thể khởi chạy phần mềm (chỉ cần nhấp đúp vào các tệp `.py` mong muốn hoặc nhập `py PC_Miner.py` vào dấu nhắc lệnh).
+
+#### Raspberry Pi (cài đặt tự động)
+
+```BASH
+wget https://raw.githubusercontent.com/revoxhere/duino-coin/master/Tools/duco-install-rpi.sh
+sudo chmod a+x duco-install-rpi.sh
+./duco-install-rpi.sh
+```
+
+## DUCO, wDUCO, bscDUCO, maticDUCO & celoDUCO
+
+Duino-Coin là một loại tiền tệ lai cung cấp hỗ trợ cho cả hai cách tập trung và phi tập trung để lưu trữ tiền. Duino-Coins có thể được chuyển đổi thành wDUCO, bscDUCO hoặc những loại khác là Duino-Coins giống nhau nhưng được "bọc" (lưu trữ) trên các mạng khác dưới dạng mã thông báo. Một hướng dẫn ví dụ về cách sử dụng wDUCO có sẵn trong [wDUCO wiki](https://github.com/revoxhere/duino-coin/wiki/wDUCO-tutorial). Tiền xu có thể được bọc trực tiếp từ Ví web của bạn - nhấp vào nút Gói tiền xu để bắt đầu.
+
+## Phát triển
+
+Những đóng góp là điều làm cho cộng đồng mã nguồn mở trở thành một nơi tuyệt vời để học hỏi, truyền cảm hứng và sáng tạo.<br>
+Bất kỳ đóng góp nào bạn thực hiện cho dự án Duino-Coin đều được đánh giá cao.
+
+Làm thế nào để giúp đỡ?
+
+*   Fork dự án
+*   Tạo nhánh tính năng của bạn
+*   Cam kết thay đổi của bạn
+*   Đảm bảo mọi thứ hoạt động như dự định
+*   Mở một yêu cầu kéo
+
+Mã nguồn máy chủ, tài liệu cho các cuộc gọi API và các thư viện chính thức để phát triển các ứng dụng của riêng bạn cho Duino-Coin có sẵn trong [công cụ hữu ích](https://github.com/revoxhere/duino-coin/tree/useful-tools) chi nhánh.
+
+
+## Mục tiêu phần thưởng phiên bản 4.0
+
+Được chụp với hệ số nhân bình thường (không tăng cường vào cuối tuần)
+| Thiết bị                | Tỷ lệ băm            | Chủ đề | DUCO/ngày | Sử dụng năng lượng |
+|-------------------------|----------------------|--------|-----------|--------------------|
+| Arduino                 | 343 H/s              | 1      | 12        | <0.5 W
+| ESP32                   | 170-180 kH/s         | 2      | 10        | 1.5-2 W
+| ESP32-S2/C3             | 85-96 kH/s           | 1      | 8         | 1-1.5 W
+| ESP8266                 | 66 kH/s              | 1      | 6         | 1-1.5 W
+| Raspberry Pi 4 (LOW)    | 1 MH/s (no fasthash) | 4      | 6-7       | 6.5 W
+| Raspberry Pi 4 (MED)    | 5.4 MH/s (fasthash)  | 4      | 7-8       | 6.5 W
+| PC công suất thấp       |                      | 4      | 4-6       | -
+| Trung bình             |                      | 4-8    | 6-10      | -
+| Cao cấp                 |                      | 8+     | 10-12     | -
+
+<details>
+  <summary><b>Các thiết bị khác đã được thử nghiệm và điểm chuẩn của chúng</b></summary>
+  
+Lưu ý rằng cột DUCO/ngày đã bị xóa kể từ khi phiên bản 4.0 thay đổi hệ thống phần thưởng.
+| Thiết bị/CPU/SBC/MCU/chip                                | Tỷ lệ băm trung bình<br>(tất cả các chủ đề) | Chủ đề khai thác | Sử dụng năng lượng |
+|-----------------------------------------------------------|--------------------------------------------|------------------|--------------------|
+| Raspberry Pi Pico                                         | 18 kH/s                                    | 1                | 0.3 W              |
+| Raspberry Pi Zero                                         | 18 kH/s                                    | 1                | 1.1 W              |
+| Raspberry Pi 3 **(32bit)**                                | 440 kH/s                                   | 4                | 5.1 W              |
+| Raspberry Pi 4 **(32bit)**                                | 740 kH/s                                   | 4                | 6.4 W              |
+| Raspberry Pi 4 **(64bit, fasthash)**                      | 6.8 MH/s                                   | 4                | 6.4 W              |
+| ODROID XU4                                                | 1.0 MH/s                                   | 8                | 5 W                |
+| Atomic Pi                                                 | 690 kH/s                                   | 4                | 6 W                |
+| Orange Pi Zero 2                                          | 740 kH/s                                   | 4                | 2.55 W             |
+| Khadas Vim 2 Pro                                          | 1.12 MH/s                                  | 8                | 6.2 W              |
+| Libre Computers Tritium H5CC                              | 480 kH/s                                   | 4                | 5 W                |
+| Libre Computers Le Potato                                 | 410 kH/s                                   | 4                | 5 W                |
+| Pine64 ROCK64                                             | 640 kH/s                                   | 4                | 5 W                |
+| Intel Celeron G1840                                       | 1.25 MH/s                                  | 2                | 53 W               |
+| Intel Core i5-2430M                                       | 1.18 MH/s                                  | 4                | 35 W               |
+| Intel Core i5-3230M                                       | 1.52 MH/s                                  | 4                | 35 W               |
+| Intel Core i5-5350U                                       | 1.35 MH/s                                  | 4                | 15 W               |
+| Intel Core i5-7200U                                       | 1.62 MH/s                                  | 4                | 15 W               |
+| Intel Core i5-8300H                                       | 3.67 MH/s                                  | 8                | 45 W               |
+| Intel Core i3-4130                                        | 1.45 MH/s                                  | 4                | 54 W               |
+| AMD Ryzen 5 2600                                          | 4.9 MH/s                                   | 12               | 65 W               |
+| AMD Ryzen R1505G **(fasthash)**                           | 8.5 MH/s                                   | 4                | 35 W               |
+| Intel Core i7-11370H **(fasthash)**                       | 17.3 MH/s                                  | 8                | 35 W               |
+| Realtek RTD1295                                           | 490 kH/s                                   | 4                | -                  |
+| Realtek RTD1295 **(fasthash)**                            | 3.89 MH/s                                  | 4                | -                  |
+
+</details>
+
+## Phần mềm do cộng đồng tạo ra
+
+### Xin lưu ý rằng những phần mềm này không được chúng tôi phát triển và chúng tôi không đảm bảo rằng việc sử dụng chúng sẽ không dẫn đến việc tài khoản bị cấm. Hãy coi chúng như một sự tò mò.
+
+  ### Các thợ mỏ khác hoạt động với Duino-Coin:
+  *   [Dockerized Duino-Coin Miner](https://github.com/simeononsecurity/docker-duino-coin) - Một phiên bản Dockerized của Duino-Coin Miner
+  *   :point_right: [**RP2040-HAT-MINING-C**](https://github.com/Wiznet/RP2040-HAT-MINING-C) - **WIZnet RP2040** ngăn xếp khai thác
+  *   [DuinoCoinEthernetMiner](https://github.com/Pumafron/DuinoCoinEthernetMiner) - Miner Arduino Ethernet Shield của Pumafron
+  *   [STM8 DUCO Miner](https://github.com/BBS215/STM8_DUCO_miner) - phần sụn STM8S để khai thác DUCO của BBS215
+  *   [DuinoCoinbyLabVIEW](https://github.com/ericddm/DuinoCoinbyLabVIEW) - thợ mỏ cho gia đình LabVIEW của ericddm
+  *   [Duino-JS](https://github.com/Hoiboy19/Duino-JS) - một thợ mỏ JavaScript mà bạn có thể dễ dàng triển khai trên trang web của mình bởi Hoiboy19
+  *   [Duinotize](https://github.com/mobilegmYT/Duinotize) - người kiếm tiền từ trang web Duino của mobilegmYT
+  *   [hauchel's duco-related stuff repository](https://github.com/hauchel/duco/) - Bộ sưu tập các mã khác nhau để khai thác DUCO trên các vi điều khiển khác
+  *   [duino-coin-php-miner](https://github.com/ricardofiorani/duino-coin-php-miner) Dockerized Miner in PHP của ricardofiorani
+  *   [duino-coin-kodi](https://github.com/SandUhrGucker/duino-coin-kodi) - Tiện ích bổ sung khai thác cho Kodi Media Center của SandUhrGucker
+  *   [MineCryptoOnWifiRouter](https://github.com/BastelPichi/MineCryptoOnWifiRouter) - tập lệnh Python để khai thác Duino-Coin trên bộ định tuyến của BastelPichi
+  *   [Duino-Coin_Android_Cluster Miner](https://github.com/DoctorEenot/DuinoCoin_android_cluster) - khai thác với ít kết nối hơn trên nhiều thiết bị của DoctorEenot
+  *   [ESPython DUCO Miner](https://github.com/fabiopolancoe/ESPython-DUCO-Miner) - thợ mỏ MicroPython cho các bảng ESP của fabiopolancoe
+  *   [DUCO Miner for Nintendo 3DS](https://github.com/BunkerInnovations/duco-3ds) - thợ mỏ Python cho Nintendo 3DS của PhereloHD & HGEpro
+  *   [Dockerized DUCO Miner](https://github.com/Alicia426/Dockerized_DUCO_Miner_minimal) - Miner in Docker của Alicia426
+  *   [NodeJS-DuinoCoin-Miner](https://github.com/LDarki/NodeJS-DuinoCoin-Miner/) - thợ mỏ NodeJS đơn giản của LDarki
+  *   [d-cpuminer](https://github.com/phantom32-0/d-cpuminer) - thợ mỏ C thuần túy của phantom32 & revoxhere
+  *   [Go Miner](https://github.com/yippiez/go-miner) của yippiez
+  *   [ducominer](https://github.com/its5Q/ducominer) của its5Q
+  *   [Thư mục thợ mỏ không chính thức](https://github.com/revoxhere/duino-coin/tree/master/Unofficial%20miners)
+      *   [Julia Miner](https://github.com/revoxhere/duino-coin/blob/master/Unofficial%20miners/Julia_Miner.jl) của revoxhere
+      *   [Ruby Miner](https://github.com/revoxhere/duino-coin/blob/master/Unofficial%20miners/Ruby_Miner.rb) của revoxhere
+      *   [Minimal Python Miner (DUCO-S1)](https://github.com/revoxhere/duino-coin/blob/master/Unofficial%20miners/Minimal_PC_Miner.py) của revoxhere
+      *   [Teensy 4.1 code for Arduino IDE](https://github.com/revoxhere/duino-coin/blob/master/Unofficial%20miners/Teensy_code/Teensy_code.ino) của joaquinbvw
+
+  ### Các công cụ khác:
+  *   [Duinogotchi](https://github.com/OSRdesign/duinogotchi) - Dự án thú cưng ảo Duino-Coin của OSRdesign
+  *   [Duino Miner](https://github.com/g7ltt/Duino-Miner) - Tệp và tài liệu của thợ mỏ DUCO dựa trên Arduino Nano của g7ltt
+  *   [DUINO Mining Rig](https://repalmakershop.com/pages/duino-mining-rig) - Tệp 3D, thiết kế PCB và hướng dẫn để tạo giàn khoan Duino của riêng bạn bởi ReP_AL
+  *   [DuinoCoin-balance-Home-Assistant](https://github.com/NL647/DuinoCoin-balance-Home-Assistant) - tiện ích bổ sung cho trợ lý gia đình hiển thị số dư của bạn bởi NL647
+  *   [ducopanel](https://github.com/ponsato/ducopanel) - một ứng dụng GUI để điều khiển các thợ mỏ Duino-Coin của bạn bởi ponsato
+  *   [Duino AVR Monitor](https://www.microsoft.com/store/apps/9NJ7HPFSR9V5) - Ứng dụng GUI Windows để giám sát các thiết bị AVR khai thác DUCO của niknak
+  *   [Duino-Coin Arduino library](https://github.com/ricaun/arduino-DuinoCoin) của ricaun
+  *   [DuinoCoinI2C](https://github.com/ricaun/DuinoCoinI2C) - Sử dụng ESP8266/ESP32 làm thiết bị chính cho Arduinos của ricaun
+  *   [Duino-Coin Mining Dashboard](https://lulaschkas.github.io/duco-mining-dashboard/) và trình trợ giúp khắc phục sự cố của Lulaschkas
+  *   [duco-miners](https://github.com/dansinclair25/duco-miners) bảng điều khiển khai thác CLI được thực hiện bởi dansinclair25
+  *   [Duco-Coin Symbol Icon ttf](https://github.com/SandUhrGucker/Duco-Coin-Symbol-Icon-ttf-.h) của SandUhrGucker
+  *   [DUCO Monitor](https://siunus.github.io/duco-monitor/) trang web thống kê tài khoản của siunus
+  *   [Duino Stats](https://github.com/Bilaboz/duino-stats) bot Discord chính thức của Bilaboz
+  *   [DuCoWallet](https://github.com/viktor02/DuCoWallet) GUI Wallet của viktor02
+  *   [Duco-widget-ios](https://github.com/naphob/duco-widget-ios) - một tiện ích Duino-Coin iOS của Naphob
+  *   [Duino Lookup](https://axorax.github.io/duino-lookup/) của axorax
+
+ Bạn cũng có thể xem một danh sách tương tự trên [trang web](https://duinocoin.com/apps).
+
+
+## Giấy phép
+
+Duino-Coin chủ yếu được phân phối theo Giấy phép MIT. Xem tệp `LICENSE` để biết thêm thông tin.
+Một số tệp của bên thứ ba được bao gồm có thể có các giấy phép khác nhau - vui lòng kiểm tra các tuyên bố `LICENSE` của họ (thường ở đầu các tệp mã nguồn).
+
+
+## Điều khoản dịch vụ
+
+Điều khoản dịch vụ của chúng tôi có sẵn tại đây: <a href="https://duinocoin.com/terms">duinocoin.com/terms</a><br/>
+
+
+## Chính sách bảo mật
+
+Chính sách bảo mật của chúng tôi có sẵn tại đây: <a href="https://duinocoin.com/privacy">duinocoin.com/privacy</a><br/>
+
+## Từ chối trách nhiệm
+
+Tuyên bố từ chối trách nhiệm của chúng tôi có sẵn tại đây: <a href="https://duinocoin.com/disclaimer">duinocoin.com/disclaimer</a><br/>
+
+
+## Người bảo trì dự án tích cực
+
+Ban đầu được tạo và duy trì bởi [@revoxhere](https://github.com/revoxhere).<br>
+Cảm ơn rất nhiều đến tất cả [những người đóng góp](https://github.com/revoxhere/duino-coin/graphs/contributors) đã giúp phát triển dự án Duino-Coin.<br>
+Truy cập [duinocoin.com/team.html](https://duinocoin.com/team.html) để biết thêm thông tin về Nhóm Duino-Coin.
+
+<hr>
+
+Liên kết dự án: [https://github.com/revoxhere/duino-coin/](https://github.com/revoxhere/duino-coin/)
+<br/>
+Liên kết trang web: [https://duinocoin.com/](https://duinocoin.com/)
+<br/>
+Trang trạng thái Duino-Coin: [https://status.duinocoin.com](https://status.duinocoin.com)


### PR DESCRIPTION
Fixes #877

Add French, Vietnamese, and Dutch translations for the README file.

* Add `Resources/README_TRANSLATIONS/README_fr_FR.md` for French translation.
* Add `Resources/README_TRANSLATIONS/README_vi_VN.md` for Vietnamese translation.
* Add `Resources/README_TRANSLATIONS/README_nl_NL.md` for Dutch translation.
* Update `Resources/README_TRANSLATIONS/README_ja_JP.md` for Japanese translation.
* Update `Resources/README_TRANSLATIONS/README_de_DE.md` for German translation.
* Update `Resources/AVR_Miner_langs.json` for German translation of the AVR Miner.

