### PR TITLE
removed outdated nonceMiner from README translations

### DIFF
--- a/Resources/README_TRANSLATIONS/README_id_ID.md
+++ b/Resources/README_TRANSLATIONS/README_id_ID.md
@@ -114,7 +114,6 @@ Setelah melakukan ini, Anda dapat meluncurkan perangkat lunak (cukup klik dua ka
   *   [ESPython DUCO Miner](https://github.com/fabiopolancoe/ESPython-DUCO-Miner) - Penambang MicroPython untuk papan modul ESP oleh fabiopolancoe
   *   [DUCO Miner for Nintendo 3DS](https://github.com/BunkerInnovations/duco-3ds) - Python miner for Nintendo 3DS by PhereloHD & HGEpro
   *   [Dockerized DUCO Miner](https://github.com/Alicia426/Dockerized_DUCO_Miner_minimal) - Penambang di Docker oleh Alicia426
-  *   [nonceMiner](https://github.com/colonelwatch/nonceMiner) - Fastest Duino-Coin miner available by colonelwatch
   *   [NodeJS-DuinoCoin-Miner](https://github.com/DarkThinking/NodeJS-DuinoCoin-Miner/) - simple NodeJS miner by DarkThinking
   *   [d-cpuminer](https://github.com/phantom32-0/d-cpuminer) - miner C murni oleh phantom32 & revoxhere
   *   [Go Miner](https://github.com/yippiez/go-miner) by yippiez

--- a/Resources/README_TRANSLATIONS/README_kr_KR.md
+++ b/Resources/README_TRANSLATIONS/README_kr_KR.md
@@ -173,7 +173,6 @@ Duino-Coin 프로젝트에 대한 기여해 주시면 감사하겠습니다.
   *   [ESPython DUCO Miner](https://github.com/fabiopolancoe/ESPython-DUCO-Miner) - ESP 보드용 MicroPython 채굴기 by fabiopolancoe
   *   [DUCO Miner for Nintendo 3DS](https://github.com/BunkerInnovations/duco-3ds) - Nintendo 3DS용 Python 채굴기 PhereloHD & HGEpro
   *   [Dockerized DUCO Miner](https://github.com/Alicia426/Dockerized_DUCO_Miner_minimal) - Docker 이용한 채굴기 by Alicia426
-  *   [nonceMiner](https://github.com/colonelwatch/nonceMiner) - 가장 빠른 Duino-Coin 채굴기 by colonelwatch
   *   [NodeJS-DuinoCoin-Miner](https://github.com/DarkThinking/NodeJS-DuinoCoin-Miner/) - 간단한 NodeJS 채굴기 by DarkThinking
   *   [d-cpuminer](https://github.com/phantom32-0/d-cpuminer) - 퓨어 C 채굴기 by phantom32 & revoxhere
   *   [Go Miner](https://github.com/yippiez/go-miner) by yippiez

--- a/Resources/README_TRANSLATIONS/README_pl_PL.md
+++ b/Resources/README_TRANSLATIONS/README_pl_PL.md
@@ -113,7 +113,6 @@ Pakiet Duino-Coin dla AUR jest utrzymywany przez by [PhereloHD](https://github.c
 *   [ESPython DUCO Miner](https://github.com/fabiopolancoe/ESPython-DUCO-Miner) by fabiopolancoe
 *   [DUCO Miner for Nintendo 3DS](https://github.com/BunkerInnovations/duco-3ds) by PhereloHD & HGEpro
 *   [Dockerized DUCO Miner](https://github.com/Alicia426/Dockerized_DUCO_Miner_minimal) by Alicia426
-*   [nonceMiner](https://github.com/colonelwatch/nonceMiner) by colonelwatch
 *   [NodeJS-DuinoCoin-Miner](https://github.com/DarkThinking/NodeJS-DuinoCoin-Miner/) by DarkThinking
 *   [d-cpuminer](https://github.com/phantom32-0/d-cpuminer) by phantom32
 *   [Go Miner](https://github.com/yippiez/go-miner) by yippiez

--- a/Resources/README_TRANSLATIONS/README_pt_BR.md
+++ b/Resources/README_TRANSLATIONS/README_pt_BR.md
@@ -165,7 +165,6 @@ O código-fonte do servidor, a documentação para chamadas de API e bibliotecas
   *   [ESPython DUCO Miner](https://github.com/fabiopolancoe/ESPython-DUCO-Miner) - Minerador em MicroPython para placas ESP, feito por fabiopolancoe
   *   [DUCO Miner for Nintendo 3DS](https://github.com/BunkerInnovations/duco-3ds) - Minerador em Python para Nintendo 3DS, feito por PhereloHD & HGEpro
   *   [Dockerized DUCO Miner](https://github.com/Alicia426/Dockerized_DUCO_Miner_minimal) - Mineradora em Docker, feito por Alicia426
-  *   [nonceMiner](https://github.com/colonelwatch/nonceMiner) - A mineradora de Duino-Coin mais rápida disponível, feita por colonelwatch
   *   [NodeJS-DuinoCoin-Miner](https://github.com/DarkThinking/NodeJS-DuinoCoin-Miner/) - Minerador simples em NodeJS, feita pelo DarkThinking
   *   [d-cpuminer](https://github.com/phantom32-0/d-cpuminer) - Mineradora em C, feito por phantom32 & revoxhere
   *   [Go Miner](https://github.com/yippiez/go-miner) por yippiez

--- a/Resources/README_TRANSLATIONS/README_ru_RU.md
+++ b/Resources/README_TRANSLATIONS/README_ru_RU.md
@@ -113,7 +113,6 @@ py -m pip install -r requirements.txt
 *   [ESPython DUCO Miner](https://github.com/fabiopolancoe/ESPython-DUCO-Miner) - MicroPython майнер для плат ESP от fabiopolancoe
 *   [DUCO Miner for Nintendo 3DS](https://github.com/BunkerInnovations/duco-3ds) - Python майнер для Nintendo 3DS от PhereloHD & HGEpro
 *   [Dockerized DUCO Miner](https://github.com/Alicia426/Dockerized_DUCO_Miner_minimal) - Майнер в докере от Alicia426
-*   [nonceMiner](https://github.com/colonelwatch/nonceMiner) - Самый быстрый из доступных майнер от colonelwatch
 *   [NodeJS-DuinoCoin-Miner](https://github.com/DarkThinking/NodeJS-DuinoCoin-Miner/) - Простой майнер NodeJS от DarkThinking
 *   [d-cpuminer](https://github.com/phantom32-0/d-cpuminer) - Майнер на чистом C от phantom32 & revox
 *   [Go Miner](https://github.com/yippiez/go-miner) От yippiez

--- a/Resources/README_TRANSLATIONS/README_th_TH.md
+++ b/Resources/README_TRANSLATIONS/README_th_TH.md
@@ -109,7 +109,6 @@ python3 -m pip install -r requirements.txt # Install pip dependencies
   *   [ESPython DUCO Miner](https://github.com/fabiopolancoe/ESPython-DUCO-Miner) - ตัวขุดไมโครไพธอนสำหรับบอร์ด ESP โดย fabiopolancoe
   *   [DUCO Miner for Nintendo 3DS](https://github.com/BunkerInnovations/duco-3ds) - ตัวขุดไพธอนสำหรับ Nintendo 3DS โดย PhereloHD & HGEpro
   *   [Dockerized DUCO Miner](https://github.com/Alicia426/Dockerized_DUCO_Miner_minimal) - ตัวขุดใน Docker โดย Alicia426
-  *   [nonceMiner](https://github.com/colonelwatch/nonceMiner) - ตัวขุด Duino-Coin อย่างเร็ว โดย colonelwatch
   *   [NodeJS-DuinoCoin-Miner](https://github.com/DarkThinking/NodeJS-DuinoCoin-Miner/) - ตัวขุด NodeJS อย่างง่าย โดย DarkThinking
   *   [d-cpuminer](https://github.com/phantom32-0/d-cpuminer) - ตัวขุด pure C โดย phantom32 & revoxhere
   *   [Go Miner](https://github.com/yippiez/go-miner) โดย yippiez

--- a/Resources/README_TRANSLATIONS/README_tr_TR.md
+++ b/Resources/README_TRANSLATIONS/README_tr_TR.md
@@ -92,7 +92,6 @@ Bunu yaptıktan sonra istediğiniz yazılımı çalıştırabilirsiniz (istediğ
   *   [ESPython DUCO Miner](https://github.com/fabiopolancoe/ESPython-DUCO-Miner) - fabiopolancoe tarafından ESP kartları için MicroPython'da yazılmmış madenci
   *   [DUCO Miner for Nintendo 3DS](https://github.com/BunkerInnovations/duco-3ds) - PhereloHD & HGEpro tarafından Nintendo 3DS için madenci yazılımı
   *   [Dockerized DUCO Miner](https://github.com/Alicia426/Dockerized_DUCO_Miner_minimal) - Alicia426 tarafından Docker içinde çalışan madenci
-  *   [nonceMiner](https://github.com/colonelwatch/nonceMiner) - colonelwatch tarafından şu ana kadar ki en hızlı madenci yazılımı
   *   [NodeJS-DuinoCoin-Miner](https://github.com/DarkThinking/NodeJS-DuinoCoin-Miner/) - DarkThinking tarafından basit bir NodeJS'de yazılmış madenci
   *   [d-cpuminer](https://github.com/phantom32-0/d-cpuminer) - phantom32 & revoxhere tarafından saf C içinde yazılmış madenci
   *   [Go Miner](https://github.com/yippiez/go-miner) yippiez tarafından Go'da yazılmış madenci

--- a/Resources/README_TRANSLATIONS/README_zh_TW.md
+++ b/Resources/README_TRANSLATIONS/README_zh_TW.md
@@ -118,7 +118,6 @@ After doing this, you are good to go with launching the software (e.g. `python3 
   *   [ESPython DUCO Miner](https://github.com/fabiopolancoe/ESPython-DUCO-Miner) - MicroPython miner for ESP boards by fabiopolancoe
   *   [DUCO Miner for Nintendo 3DS](https://github.com/BunkerInnovations/duco-3ds) - Python miner for Nintendo 3DS by PhereloHD & HGEpro
   *   [Dockerized DUCO Miner](https://github.com/Alicia426/Dockerized_DUCO_Miner_minimal) - Miner in Docker by Alicia426
-  *   [nonceMiner](https://github.com/colonelwatch/nonceMiner) - Fastest Duino-Coin miner available by colonelwatch
   *   [NodeJS-DuinoCoin-Miner](https://github.com/DarkThinking/NodeJS-DuinoCoin-Miner/) - simple NodeJS miner by DarkThinking
   *   [d-cpuminer](https://github.com/phantom32-0/d-cpuminer) - pure C miner by phantom32 & revoxhere
   *   [Go Miner](https://github.com/yippiez/go-miner) by yippiez


### PR DESCRIPTION
Nonceminer hasn't been updated in years and doesn't work properly with current server revisions anymore.
Therefore, it is removed from all READMEs, so that non-english speaking miners are not mislead.