### PR TITLE
locale fix: getdefaultlocale depracate

### DIFF
--- a/AVR_Miner.py
+++ b/AVR_Miner.py
@@ -42,8 +42,6 @@ printlock = Lock()
 # Python <3.5 check
 f"Your Python version is too old. Duino-Coin Miner requires version 3.6 or above. Update your packages and try again"
 
-setlocale(LC_ALL, "cs_CZ")
-
 def install(package):
     try:
         pip.main(["install",  package])

--- a/AVR_Miner.py
+++ b/AVR_Miner.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 from json import load as jsonload
 from random import choice
-from locale import LC_ALL, getlocale, setlocale
+from locale import getlocale, setlocale, normalize, LC_ALL
 import zipfile
 
 from re import sub
@@ -42,6 +42,7 @@ printlock = Lock()
 # Python <3.5 check
 f"Your Python version is too old. Duino-Coin Miner requires version 3.6 or above. Update your packages and try again"
 
+setlocale(LC_ALL, "cs_CZ")
 
 def install(package):
     try:
@@ -508,7 +509,14 @@ if system() == 'Darwin':
 
 try:
     if not Path(Settings.DATA_DIR + '/Settings.cfg').is_file():
-        locale = getlocale()[0]
+        setlocale(LC_ALL, '')
+
+        locale_raw = getlocale()[0]
+        if not locale_raw:   
+            lang = "english"  
+
+        locale = normalize(locale_raw)
+
         if locale.startswith("es"):
             lang = "spanish"
         elif locale.startswith("pl"):

--- a/AVR_Miner.py
+++ b/AVR_Miner.py
@@ -138,6 +138,44 @@ class Settings:
             PICK = ""
             COG = " @"
 
+def get_win32_locale() -> str:
+    """
+    Windows's alternative to getlocale
+    """
+    from ctypes import (create_unicode_buffer,
+                        FormatError,
+                        GetLastError,
+                        windll)
+    bufsize = 85
+    buf = create_unicode_buffer(bufsize)
+    if windll.kernel32.GetUserDefaultLocaleName(buf, bufsize):
+        return buf.value
+    else:
+        raise OSError(FormatError(GetLastError()))
+
+def get_locale_code() -> str:
+    """
+    Wrapper to handle getlocale for all OSes
+    Reaction to: https://github.com/python/cpython/issues/90817
+    """
+
+    if os.name == 'nt':
+        try:
+            return get_win32_locale()
+        except: 
+            return "english"
+    elif os.name == "posix":
+        setlocale(LC_ALL, '')
+
+        locale_raw = getlocale()[0]
+        if locale_raw:     
+            return normalize(locale_raw)
+
+        return "english"
+    else:
+        return "english"
+
+
 def check_updates():
     """
     Function that checks if the miner is updated.
@@ -507,13 +545,7 @@ if system() == 'Darwin':
 
 try:
     if not Path(Settings.DATA_DIR + '/Settings.cfg').is_file():
-        setlocale(LC_ALL, '')
-
-        locale_raw = getlocale()[0]
-        if not locale_raw:   
-            lang = "english"  
-
-        locale = normalize(locale_raw)
+        locale = get_locale_code()
 
         if locale.startswith("es"):
             lang = "spanish"

--- a/AVR_Miner.py
+++ b/AVR_Miner.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 from json import load as jsonload
 from random import choice
-from locale import LC_ALL, getdefaultlocale, getlocale, setlocale
+from locale import LC_ALL, getlocale, setlocale
 import zipfile
 
 from re import sub
@@ -508,45 +508,51 @@ if system() == 'Darwin':
 
 try:
     if not Path(Settings.DATA_DIR + '/Settings.cfg').is_file():
-        locale = getdefaultlocale()[0]
-        if locale.startswith('es'):
-            lang = 'spanish'
-        elif locale.startswith('sk'):
-            lang = 'slovak'
-        elif locale.startswith('ru'):
-            lang = 'russian'
-        elif locale.startswith('pl'):
-            lang = 'polish'
-        elif locale.startswith('de'):
-            lang = 'german'
-        elif locale.startswith('fr'):
-            lang = 'french'
-        elif locale.startswith('jp'):
-            lang = 'japanese'
-        elif locale.startswith('tr'):
-            lang = 'turkish'
-        elif locale.startswith('it'):
-            lang = 'italian'
-        elif locale.startswith('pt'):
-            lang = 'portuguese'
-        if locale.startswith("zh_TW"):
+        locale = getlocale()[0]
+        if locale.startswith("es"):
+            lang = "spanish"
+        elif locale.startswith("pl"):
+            lang = "polish"
+        elif locale.startswith("fr"):
+            lang = "french"
+        elif locale.startswith("ja"):
+            lang = "japanese"
+        elif locale.startswith("fa"):
+            lang = "farsi"
+        elif locale.startswith("mt"):
+            lang = "maltese"
+        elif locale.startswith("ru"):
+            lang = "russian"
+        elif locale.startswith("uk"):
+            lang = "ukrainian"
+        elif locale.startswith("de"):
+            lang = "german"
+        elif locale.startswith("tr"):
+            lang = "turkish"
+        elif locale.startswith("pt"):
+            lang = "portuguese"
+        elif locale.startswith("it"):
+            lang = "italian"
+        elif locale.startswith("sk"):
+            lang = "slovak"
+        elif locale.startswith("zh_Hant") or locale.startswith("zh_TW"):
             lang = "chinese_Traditional"
-        elif locale.startswith('zh'):
-            lang = 'chinese_simplified'
-        elif locale.startswith('th'):
-            lang = 'thai'
+        elif locale.startswith("zh"):
+            lang = "chinese_simplified"                
+        elif locale.startswith("th"):
+            lang = "thai"
+        elif locale.startswith("ko"):
+            lang = "korean"
+        elif locale.startswith("id"):
+            lang = "indonesian"
+        elif locale.startswith("cs"):
+            lang = "czech"
+        elif locale.startswith("fi"):
+            lang = "finnish"
         elif locale.startswith('az'):
             lang = 'azerbaijani'
         elif locale.startswith('nl'):
             lang = 'dutch'
-        elif locale.startswith('ko'):
-            lang = 'korean'
-        elif locale.startswith("id"):
-            lang = "indonesian"
-        elif locale.startswith("cz"):
-            lang = "czech"
-        elif locale.startswith("fi"):
-            lang = "finnish"
         else:
             lang = 'english'
     else:

--- a/PC_Miner.py
+++ b/PC_Miner.py
@@ -960,7 +960,7 @@ class Miner:
                     lang = "italian"
                 elif locale.startswith("sk"):
                     lang = "slovak"
-                if locale.startswith("zh_Hant") or locale.startswith("zh_TW"):
+                elif locale.startswith("zh_Hant") or locale.startswith("zh_TW"):
                     lang = "chinese_Traditional"
                 elif locale.startswith("zh"):
                     lang = "chinese_simplified"                

--- a/PC_Miner.py
+++ b/PC_Miner.py
@@ -37,7 +37,7 @@ from platform import python_version_tuple
 from platform import python_version
 
 from signal import SIGINT, signal
-from locale import getdefaultlocale
+from locale import getlocale
 from configparser import ConfigParser
 
 import io
@@ -63,15 +63,18 @@ def handler(signal_received, frame):
             + get_string("goodbye"),
             "warning")
     
-    if not "raspi_leds" in user_settings:
-        user_settings["raspi_leds"] = "y"
-    
-    if running_on_rpi and user_settings["raspi_leds"] == "y":
-        # Reset onboard status LEDs
-        os.system(
-            'echo mmc0 | sudo tee /sys/class/leds/led0/trigger >/dev/null 2>&1')
-        os.system(
-            'echo 1 | sudo tee /sys/class/leds/led1/brightness >/dev/null 2>&1')
+    try:
+        if not "raspi_leds" in user_settings:
+            user_settings["raspi_leds"] = "y"
+        
+        if running_on_rpi and user_settings["raspi_leds"] == "y":
+            # Reset onboard status LEDs
+            os.system(
+                'echo mmc0 | sudo tee /sys/class/leds/led0/trigger >/dev/null 2>&1')
+            os.system(
+                'echo 1 | sudo tee /sys/class/leds/led1/brightness >/dev/null 2>&1')
+    except:
+        pass
 
     if sys.platform == "win32":
         _exit(0)
@@ -895,14 +898,14 @@ class Miner:
 
         try:
             if not Path(Settings.DATA_DIR + Settings.SETTINGS_FILE).is_file():
-                locale = getdefaultlocale()[0]
+                locale = getlocale()[0]
                 if locale.startswith("es"):
                     lang = "spanish"
                 elif locale.startswith("pl"):
                     lang = "polish"
                 elif locale.startswith("fr"):
                     lang = "french"
-                elif locale.startswith("jp"):
+                elif locale.startswith("ja"):
                     lang = "japanese"
                 elif locale.startswith("fa"):
                     lang = "farsi"
@@ -916,13 +919,13 @@ class Miner:
                     lang = "german"
                 elif locale.startswith("tr"):
                     lang = "turkish"
-                elif locale.startswith("pr"):
+                elif locale.startswith("pt"):
                     lang = "portuguese"
                 elif locale.startswith("it"):
                     lang = "italian"
                 elif locale.startswith("sk"):
                     lang = "slovak"
-                if locale.startswith("zh_TW"):
+                if locale.startswith("zh_Hant") or locale.startswith("zh_TW"):
                     lang = "chinese_Traditional"
                 elif locale.startswith("zh"):
                     lang = "chinese_simplified"                
@@ -932,7 +935,7 @@ class Miner:
                     lang = "korean"
                 elif locale.startswith("id"):
                     lang = "indonesian"
-                elif locale.startswith("cz"):
+                elif locale.startswith("cs"):
                     lang = "czech"
                 elif locale.startswith("fi"):
                     lang = "finnish"

--- a/PC_Miner.py
+++ b/PC_Miner.py
@@ -37,7 +37,7 @@ from platform import python_version_tuple
 from platform import python_version
 
 from signal import SIGINT, signal
-from locale import getlocale
+from locale import getlocale, setlocale, normalize, LC_ALL
 from configparser import ConfigParser
 
 import io
@@ -49,7 +49,6 @@ printlock = Lock()
 
 # Python <3.5 check
 f"Your Python version is too old. Duino-Coin Miner requires version 3.6 or above. Update your packages and try again"
-
 
 def handler(signal_received, frame):
     """
@@ -898,7 +897,13 @@ class Miner:
 
         try:
             if not Path(Settings.DATA_DIR + Settings.SETTINGS_FILE).is_file():
-                locale = getlocale()[0]
+                setlocale(LC_ALL, '')
+
+                locale_raw = getlocale()[0]
+                if not locale_raw:   
+                    lang = "english"  
+
+                locale = normalize(locale_raw)
                 if locale.startswith("es"):
                     lang = "spanish"
                 elif locale.startswith("pl"):

--- a/PC_Miner.py
+++ b/PC_Miner.py
@@ -191,6 +191,42 @@ class Settings:
             PICK = ""
             COG = " @"
 
+def get_win32_locale() -> str:
+    """
+    Windows's alternative to getlocale
+    """
+    from ctypes import (create_unicode_buffer,
+                        FormatError,
+                        GetLastError,
+                        windll)
+    bufsize = 85
+    buf = create_unicode_buffer(bufsize)
+    if windll.kernel32.GetUserDefaultLocaleName(buf, bufsize):
+        return buf.value
+    else:
+        raise OSError(FormatError(GetLastError()))
+
+def get_locale_code() -> str:
+    """
+    Wrapper to handle getlocale for all OSes
+    Reaction to: https://github.com/python/cpython/issues/90817
+    """
+
+    if os.name == 'nt':
+        try:
+            return get_win32_locale()
+        except: 
+            return "english"
+    elif os.name == "posix":
+        setlocale(LC_ALL, '')
+
+        locale_raw = getlocale()[0]
+        if locale_raw:     
+            return normalize(locale_raw)
+
+        return "english"
+    else:
+        return "english"
 
 def title(title: str):
     if not Settings.disable_title:
@@ -897,13 +933,7 @@ class Miner:
 
         try:
             if not Path(Settings.DATA_DIR + Settings.SETTINGS_FILE).is_file():
-                setlocale(LC_ALL, '')
-
-                locale_raw = getlocale()[0]
-                if not locale_raw:   
-                    lang = "english"  
-
-                locale = normalize(locale_raw)
+                locale = get_locale_code()
                 if locale.startswith("es"):
                     lang = "spanish"
                 elif locale.startswith("pl"):


### PR DESCRIPTION
Python `locale` lib function `getdefaultlocale` is going to get deprecated in the new python 3.15 release.
To prepare both `AVR_Miner.py` and `PC_Miner.py` to keep functioning in the new release, I replaced `getfaultlocale` with `getlocale`

Also few of more fixes were made:

**All fixes:**
1. Replaced `getdefaultlocale` with `getlocale` to prepeare the code for python 3.15
2. Fixed locale names, some of them were incorrect such as `cz` -> `cs` (Czech locale starts with cs `cs_CZ`)
3. Now function `handler` in `PC_Miner.py` wont threw error when `user_settings` were not parsed yet, such as before entering username